### PR TITLE
Add Fashion-MNIST image directory to the registry

### DIFF
--- a/fashion-mnist/.gitignore
+++ b/fashion-mnist/.gitignore
@@ -1,2 +1,3 @@
 /raw
 /images
+/images.tar.gz

--- a/fashion-mnist/.gitignore
+++ b/fashion-mnist/.gitignore
@@ -1,1 +1,2 @@
 /raw
+/images

--- a/fashion-mnist/images.dvc
+++ b/fashion-mnist/images.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 0ebacd64e04c0e4a97d8fa48a4d707e6.dir
+  size: 35401667
+  nfiles: 70000
+  path: images

--- a/fashion-mnist/images.tar.gz.dvc
+++ b/fashion-mnist/images.tar.gz.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: 3c8f026df7c3973bcec8e9f945026eb2
+  size: 34312619
+  path: images.tar.gz


### PR DESCRIPTION
* Adds `fashion-mnist/images/` directory with the structure  

```
.
├── test
│   ├── 0
│   ├── 1
│   ├── 2
│   ├── 3
│   ├── 4
│   ├── 5
│   ├── 6
│   ├── 7
│   ├── 8
│   └── 9
└── train
    ├── 0
    ├── 1
    ├── 2
    ├── 3
    ├── 4
    ├── 5
    ├── 6
    ├── 7
    ├── 8
    └── 9
```

* `fashion-mnist/images/train/0..9` contains the training set
* `fashion-mnist/images/test/0..9` contains the testing set 
* `fashion-mnist/images/images.tar.gz` contains a `tar.gz` file that has these images as a single file. 

Closes #18 