### PR TITLE
Added separate images for MNIST

### DIFF
--- a/mnist/.gitignore
+++ b/mnist/.gitignore
@@ -1,2 +1,3 @@
 /raw
 /images
+/images.tar.gz

--- a/mnist/.gitignore
+++ b/mnist/.gitignore
@@ -1,1 +1,2 @@
 /raw
+/images

--- a/mnist/images.dvc
+++ b/mnist/images.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: e42412b82dcab425ce9c7e2d0abdfb78.dir
+  size: 19258482
+  nfiles: 70000
+  path: images

--- a/mnist/images.tar.gz.dvc
+++ b/mnist/images.tar.gz.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: acb39268fb9dd785aac887f69b89282e
+  size: 17397876
+  path: images.tar.gz


### PR DESCRIPTION
This one is similar to #19 in structure. 

* Adds `mnist/images/` that holds 70,000 separate PNG images of MNIST dataset.
* Adds `mnist/images.tar.gz` that's the gzipped version of this directory. 

Closes #17 