### PR TITLE
Minify `.dvc/config` diff

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,4 @@
-['remote "storage"']
-url = https://remote.dvc.org/dataset-registry
 [core]
-remote = storage
+    remote = storage
+['remote "storage"']
+    url = https://remote.dvc.org/dataset-registry


### PR DESCRIPTION
When running `dvc remote add local /tmp/dvc-storage` as per README instructions the ini config is slightly reformatted when it's being processed and dumped. This slight change makes sure only the new remote lines are added

With this change, that's the diff for `dvc remote add local /tmp/dvc-storage`:
```bash
diff --git a/.dvc/config b/.dvc/config
index f2c7689..16b780b 100644
--- a/.dvc/config
+++ b/.dvc/config
@@ -2,3 +2,5 @@
     remote = storage
 ['remote "storage"']
     url = https://remote.dvc.org/dataset-registry
+['remote "local"']
+    url = /tmp/dvc-storage
```