### PR TITLE
add more StackOverflow data samples (4x)

### DIFF
--- a/get-started/data.xml.dvc
+++ b/get-started/data.xml.dvc
@@ -1,5 +1,5 @@
 wdir: ..
 outs:
 - path: get-started/data.xml
-  md5: a304afb96060aad90176268345e10355
-  size: 37891850
+  md5: c1fa36d90caa8489a317eee917d8bf03
+  size: 152077443


### PR DESCRIPTION
Adding more data to codify the https://github.com/iterative/example-get-started/tree/try-large-dataset branch in the example get started (it's being used in the Studio demo project here https://studio.iterative.ai/user/shcheklein/views/example-get-started-yj0q1nba3g

After this is merged and tag is assigned I'll revert it back to keep HEAD at 25K samples to make it faster and easier to deal with in the get started docs project. 