### PR TITLE
Revert get started to be 25K by default (HEAD)

### DIFF
--- a/get-started/data.xml.dvc
+++ b/get-started/data.xml.dvc
@@ -1,5 +1,5 @@
 wdir: ..
 outs:
 - path: get-started/data.xml
-  md5: c1fa36d90caa8489a317eee917d8bf03
-  size: 152077443
+  md5: a304afb96060aad90176268345e10355
+  size: 37891850


### PR DESCRIPTION
Follow up #25 to make default HEAD dataset smaller. 100K now is tagged can be accessed using the `--rev` flag.