### PR TITLE
get-started: replace with R-lang labeled posts

### DIFF
--- a/get-started/data.xml.dvc
+++ b/get-started/data.xml.dvc
@@ -1,5 +1,5 @@
 outs:
 - path: data.xml
-  md5: 4bd325a30d5f1d5ea1a451d98767ddde
-  size: 59918667
-  desc: 40K StackOverflow posts (1/3 is R lang)
+  md5: 22a1a2931c8370d3aeedd7183606fd7f
+  size: 14445097
+  desc: 10K StackOverflow posts (1/3 is R lang)

--- a/get-started/data.xml.dvc
+++ b/get-started/data.xml.dvc
@@ -1,5 +1,5 @@
-wdir: ..
 outs:
-- path: get-started/data.xml
-  md5: a304afb96060aad90176268345e10355
-  size: 37891850
+- path: data.xml
+  md5: 4bd325a30d5f1d5ea1a451d98767ddde
+  size: 59918667
+  desc: 40K StackOverflow posts (1/3 is R lang)


### PR DESCRIPTION
I'm migrating get started to a better dataset. A bit more balanced + all posts are labeled + I'll be using R tag, not Python since it makes the problem a bit more interesting and results less predictable.

Also there will be now two datasets 10K and 40K + we'll change the number of features in the get started itself to 100-200. All these things will make the project more stable, metrics make more sense, memory footprint goes significantly down (need to test on docker to what is the minimum now).

This PR should be rebased to keep the sequence 40k, 10K (HEAD). 40K will be fetched using tags.