### PR TITLE
add 2nd remote for docs/dvc

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -2,3 +2,5 @@
     remote = storage
 ['remote "storage"']
     url = https://remote.dvc.org/dataset-registry
+['remote "docs/dvc"']
+    url = https://remote.dvc.org/docs/dvc

--- a/get-started/data.xml.dvc
+++ b/get-started/data.xml.dvc
@@ -3,3 +3,4 @@ outs:
   md5: 22a1a2931c8370d3aeedd7183606fd7f
   size: 14445097
   desc: 10K StackOverflow posts (1/3 is R lang)
+  remote: docs/dvc

--- a/tutorials/nlp/Posts.xml.zip.dvc
+++ b/tutorials/nlp/Posts.xml.zip.dvc
@@ -3,3 +3,4 @@ outs:
 - path: tutorials/nlp/Posts.xml.zip
   md5: ce68b98d82545628782c66192c96f2d2
   size: 10567868
+  remote: docs/dvc

--- a/tutorials/nlp/pipeline.zip.dvc
+++ b/tutorials/nlp/pipeline.zip.dvc
@@ -3,3 +3,4 @@ outs:
 - path: tutorials/nlp/pipeline.zip
   md5: 1d2070ee188fc5e4d94ad920e6cc82aa
   size: 4687
+  remote: docs/dvc

--- a/tutorials/versioning/data.zip.dvc
+++ b/tutorials/versioning/data.zip.dvc
@@ -3,3 +3,4 @@ outs:
 - path: tutorials/versioning/data.zip
   md5: fa9c0eb4173d86695b4e800219651360
   size: 41122310
+  remote: docs/dvc

--- a/tutorials/versioning/new-labels.zip.dvc
+++ b/tutorials/versioning/new-labels.zip.dvc
@@ -3,3 +3,4 @@ outs:
 - path: tutorials/versioning/new-labels.zip
   md5: 2eaa473159443e75e6fb7b29e56c0787
   size: 22950744
+  remote: docs/dvc

--- a/use-cases/cats-dogs.dvc
+++ b/use-cases/cats-dogs.dvc
@@ -3,3 +3,4 @@ outs:
   md5: 22e3f61e52c0ba45334d973244efc155.dir
   size: 64128504
   nfiles: 2800
+  remote: docs/dvc


### PR DESCRIPTION
Adds another remote for data that is part of dvc docs.

Some motivation for this:
* Show usage of multiple remotes and specifying a remote per output.
* Have a test repo for issues like https://github.com/iterative/studio/issues/4442#issuecomment-1330045379.
* Drive product feedback on these features (for example, it would be nice to be able to configure all .dvc files in a location to use a specified remote instead of finding and editing every .dvc file).
* Organize data (related to #34).