### PR TITLE
add get-started/data.xml as an artifact

### DIFF
--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,0 +1,8 @@
+artifacts:
+  get-started-data:
+    path: get-started/data.xml.dvc
+    type: data
+    desc: 'Stack Overflow questions'
+    labels:
+      - nlp
+      - classification


### PR DESCRIPTION
This enables us to demo non-model artifacts in the registry and reference them in docs (like in https://dvc.org/doc/user-guide/data-management/discovering-and-accessing-data and https://dvc.org/doc/use-cases/data-registry/tutorial).