### PR TITLE
change artifact type from data to dataset

### DIFF
--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,7 +1,7 @@
 artifacts:
   get-started-data:
     path: get-started/data.xml.dvc
-    type: data
+    type: dataset
     desc: 'Stack Overflow questions'
     labels:
       - nlp


### PR DESCRIPTION
I missed that we already use type `dataset` in example-get-started, so let's use the same here for consistency:

<img width="1433" alt="Screenshot 2024-01-08 at 8 32 39 AM" src="https://github.com/iterative/dataset-registry/assets/2308172/86219b89-cf8a-41b4-a0f7-b7506484af80">
