### PR TITLE
add dvc discord corpus for llm workshop

### DIFF
--- a/workshop/.gitignore
+++ b/workshop/.gitignore
@@ -1,1 +1,2 @@
 /satellite-data
+/dvc_discord_channel.csv

--- a/workshop/dvc_discord_channel.csv.dvc
+++ b/workshop/dvc_discord_channel.csv.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: c99631b236e0daa26c7658382c91c1f3
+  size: 9265543
+  hash: md5
+  path: dvc_discord_channel.csv


### PR DESCRIPTION
In addition to the main git corpus that can be downloaded without dvc, I decided to add this discord dump to let people play around with some realistic data in the workshop.